### PR TITLE
Fixing some errors.

### DIFF
--- a/src/scripts/appelements.js
+++ b/src/scripts/appelements.js
@@ -112,7 +112,8 @@ export default {
         let l = localStorage.getItem('lvlcode');
         //localStorage.setItem('lvlcode', l);
 
-        renderer.init(canvas, levelparse.code2object(l));
+        renderer.init(canvas);
+        renderer.initLevel(levelparse.code2object(l));
         renderer.update(canvas);
         setInterval(() => {
             renderer.update(canvas);

--- a/src/scripts/canvas.js
+++ b/src/scripts/canvas.js
@@ -3,19 +3,17 @@ import {EditorLevel} from './level';
 let gl, renderer, cvs, options, level;
 
 export default {
-    init: (canvas, lvl) => {
+    init: (canvas) => {
         options = {
             grid: true
         };
         gl = canvas.getContext("webgl");
         renderer = new GDRenderer(gl);
         cvs = canvas;
-        renderer.loadGDExtLevel(lvl);
-        renderer.renderLevel(cvs.width, cvs.height, options);
     },
     update: (canvas) => {
         if(!canvas) return;
-        renderer.renderLevel(canvas.width, canvas.height, options);
+        renderer.renderLevel(level, canvas.width, canvas.height, options);
     },
     moveTo: (x, y, z) => {
         renderer.camera.x = x;


### PR DESCRIPTION
`renderer.loadGDExt(lvl)` is deprecated.

Instead, the level gets loaded with `EditorLevel` and 
gets rendered using `renderer.renderLevel( EditorLevel level, number width, number height, Object options );`